### PR TITLE
Add softdevice_v5 handlers: exchange of default MTU and TX complete

### DIFF
--- a/python/pc_ble_driver_py/ble_adapter.py
+++ b/python/pc_ble_driver_py/ble_adapter.py
@@ -468,7 +468,7 @@ class BLEAdapter(BLEDriverObserver):
     def on_gattc_evt_write_cmd_tx_complete(self, ble_driver, conn_handle, **kwargs):
         self.evt_sync[conn_handle].notify(evt = BLEEvtID.gattc_evt_write_cmd_tx_complete, data = kwargs)
 
-    def on_gattc_evt_write_rsvp(self, ble_driver, conn_handle, **kwargs):
+    def on_gattc_evt_write_rsp(self, ble_driver, conn_handle, **kwargs):
         self.evt_sync[conn_handle].notify(evt = BLEEvtID.gattc_evt_write_rsp, data = kwargs)
 
     def on_gap_evt_conn_param_update(self, ble_driver, conn_handle, **kwargs):
@@ -494,9 +494,6 @@ class BLEAdapter(BLEDriverObserver):
 
     def on_gatts_evt_write(self, ble_driver, conn_handle, **kwargs):
         self.evt_sync[conn_handle].notify(evt=BLEEvtID.gatts_evt_write, data=kwargs)
-
-    def on_gatts_evt_exchange_mtu_request(self, ble_driver, conn_handle, client_mtu):
-        self.driver.ble_gatts_exchange_mtu_reply(conn_handle, self.default_mtu)
 
     def on_gap_evt_data_length_update_request(self, ble_driver, conn_handle, data_length_params):
         self.driver.ble_gap_data_length_update(conn_handle, None, None)

--- a/python/pc_ble_driver_py/ble_adapter.py
+++ b/python/pc_ble_driver_py/ble_adapter.py
@@ -120,6 +120,7 @@ class BLEAdapter(BLEDriverObserver):
         self.observers          = list()
         self.db_conns           = dict()
         self.evt_sync           = dict()
+        self.default_mtu        = 23
 
     def open(self):
         self.driver.open()
@@ -464,7 +465,10 @@ class BLEAdapter(BLEDriverObserver):
     def on_evt_tx_complete(self, ble_driver, conn_handle, **kwargs):
         self.evt_sync[conn_handle].notify(evt = BLEEvtID.evt_tx_complete, data = kwargs)
 
-    def on_gattc_evt_write_rsp(self, ble_driver, conn_handle, **kwargs):
+    def on_gattc_evt_write_cmd_tx_complete(self, ble_driver, conn_handle, **kwargs):
+        self.evt_sync[conn_handle].notify(evt = BLEEvtID.gattc_evt_write_cmd_tx_complete, data = kwargs)
+
+    def on_gattc_evt_write_rsvp(self, ble_driver, conn_handle, **kwargs):
         self.evt_sync[conn_handle].notify(evt = BLEEvtID.gattc_evt_write_rsp, data = kwargs)
 
     def on_gap_evt_conn_param_update(self, ble_driver, conn_handle, **kwargs):
@@ -482,11 +486,23 @@ class BLEAdapter(BLEDriverObserver):
     def on_gattc_evt_desc_disc_rsp(self, ble_driver, conn_handle, **kwargs):
         self.evt_sync[conn_handle].notify(evt = BLEEvtID.gattc_evt_desc_disc_rsp, data = kwargs)
 
+    def on_gatts_evt_hvn_tx_complete(self, ble_driver, conn_handle, **kwargs):
+        self.evt_sync[conn_handle].notify(evt = BLEEvtID.gatts_evt_hvn_tx_complete, data = kwargs)
+
     def on_gatts_evt_hvc(self, ble_driver, status, error_handle, attr_handle, **kwargs):
         self.evt_sync[conn_handle].notify(evt=BLEEvtID.gatts_evt_hvc, data=kwargs)
 
     def on_gatts_evt_write(self, ble_driver, conn_handle, **kwargs):
         self.evt_sync[conn_handle].notify(evt=BLEEvtID.gatts_evt_write, data=kwargs)
+
+    def on_gatts_evt_exchange_mtu_request(self, ble_driver, conn_handle, client_mtu):
+        self.driver.ble_gatts_exchange_mtu_reply(conn_handle, self.default_mtu)
+
+    def on_gap_evt_data_length_update_request(self, ble_driver, conn_handle, data_length_params):
+        self.driver.ble_gap_data_length_update(conn_handle, None, None)
+
+    def on_gatts_evt_exchange_mtu_request(self, ble_driver, conn_handle, client_mtu):
+        self.driver.ble_gatts_exchange_mtu_reply(conn_handle, self.default_mtu)
 
     def on_att_mtu_exchanged(self, ble_driver, conn_handle, att_mtu):
         self.db_conns[conn_handle].att_mtu = att_mtu

--- a/python/pc_ble_driver_py/observers.py
+++ b/python/pc_ble_driver_py/observers.py
@@ -119,6 +119,8 @@ class BLEDriverObserver(object):
     def on_gatts_evt_exchange_mtu_request(self, ble_driver, conn_handle, client_mtu):
         pass
 
+    def on_gattc_evt_exchange_mtu_rsp(self, ble_driver, conn_handle, **kwargs):
+        pass
 
 class BLEAdapterObserver(object):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Add default handlers for:
 - hvn/cmd TX complete events: pass events to the adapter
 - MTU exchange: set default MTU
 - data update length request
