### PR TITLE
Feature/s132v5 py3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,14 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.11)
 
 # Name of the project
 project (pc-ble-driver-py)
 
 if(NOT ${PYTHON_VERSION})
     # Set default Python version to link with
-    set(PYTHON_VERSION 2.7)
+    set(PYTHON_VERSION 3.4)
 endif()
 
 set(PC_BLE_DRIVER_PY_OUTDIR ${CMAKE_BINARY_DIR}/outdir)
-
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PC_BLE_DRIVER_PY_OUTDIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PC_BLE_DRIVER_PY_OUTDIR})
@@ -80,7 +79,7 @@ foreach(SD_API_VER ${SD_API_VERS})
     string(REGEX MATCH "[0-9]+$" _SD_API_VER_NUM "${SD_API_VER}")
     set(SD_API_VER_COMPILER_DEF_NUM "-D${SD_API_VER_COMPILER_DEF}=${_SD_API_VER_NUM}")
     set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} "${SD_API_VER_COMPILER_DEF_NUM}")
-    swig_add_module(${PYTHON_MODULE_${SD_API_VER}} python ${SWIG_I_FILE_${SD_API_VER}})
+    swig_add_library(${PYTHON_MODULE_${SD_API_VER}} LANGUAGE python SOURCES ${SWIG_I_FILE_${SD_API_VER}})
     target_include_directories(${SWIG_MODULE_${PYTHON_MODULE_${SD_API_VER}}_REAL_NAME} PRIVATE ${PC_BLE_DRIVER_${SD_API_VER}_PUBLIC_INCLUDE_DIRS})
 endforeach(SD_API_VER)
 
@@ -198,6 +197,3 @@ foreach(i RANGE ${_COUNT})
         COMMAND ${CMAKE_COMMAND} -E md5sum ${PC_BLE_DRIVER_${SD_API_VER}_SHARED_LIB_FILE} >> ${PY_MODULE_BUILD_INFO_POST_PATH} WORKING_DIRECTORY ${PY_MODULE_SHARED_LIB_DIR}
     )
 endforeach(i)
-
-
-

--- a/swig/pc_ble_driver.i.in
+++ b/swig/pc_ble_driver.i.in
@@ -67,6 +67,349 @@
 // Ignore event getter, handled by the connectivity device
 %ignore sd_ble_evt_get;
 
+// Workaround for bug in SWIG, see https://github.com/swig/swig/issues/1305
+%inline %{
+#if NRF_SD_BLE_API_VERSION == 5
+    // SoftDevice V5
+
+    // ble.h
+    // Forward declaration of structs
+    typedef struct ble_evt_user_mem_request_t ble_evt_user_mem_request_t;
+    typedef struct ble_gap_conn_cfg_t ble_gap_conn_cfg_t;
+    typedef struct ble_gattc_conn_cfg_t ble_gattc_conn_cfg_t;
+    typedef struct ble_gatt_conn_cfg_t ble_gatt_conn_cfg_t;
+    typedef struct ble_l2cap_conn_cfg_t ble_l2cap_conn_cfg_t;
+
+    typedef struct
+    {
+      uint16_t conn_handle;                                 /**< Connection Handle on which this event occurred. */
+      union
+      {
+        ble_evt_user_mem_request_t      user_mem_request;    /**< User Memory Request Event Parameters. */
+        ble_evt_user_mem_release_t      user_mem_release;    /**< User Memory Release Event Parameters. */
+      } params;                                              /**< Event parameter union. */
+    } ble_common_evt_t;
+
+    typedef struct
+    {
+      uint8_t              conn_cfg_tag;        /**< The application chosen tag it can use with the @ref sd_ble_gap_adv_start() and @ref sd_ble_gap_connect()
+                                                     calls to select this configuration when creating a connection.
+                                                     Must be different for all connection configurations added and not @ref BLE_CONN_CFG_TAG_DEFAULT. */
+      union
+      {
+        ble_gap_conn_cfg_t   gap_conn_cfg;      /**< GAP connection configuration, cfg_id is @ref BLE_CONN_CFG_GAP. */
+        ble_gattc_conn_cfg_t gattc_conn_cfg;    /**< GATTC connection configuration, cfg_id is @ref BLE_CONN_CFG_GATTC. */
+        ble_gatts_conn_cfg_t gatts_conn_cfg;    /**< GATTS connection configuration, cfg_id is @ref BLE_CONN_CFG_GATTS. */
+        ble_gatt_conn_cfg_t  gatt_conn_cfg;     /**< GATT connection configuration, cfg_id is @ref BLE_CONN_CFG_GATT. */
+        ble_l2cap_conn_cfg_t l2cap_conn_cfg;    /**< L2CAP connection configuration, cfg_id is @ref BLE_CONN_CFG_L2CAP. */
+      } params;                                 /**< Connection configuration union. */
+    } ble_conn_cfg_t;
+
+    // ble_gap.h
+    // Forward declaration of structs
+    typedef struct ble_gap_evt_connected_t ble_gap_evt_connected_t;
+    typedef struct ble_gap_evt_disconnected_t ble_gap_evt_disconnected_t;
+    typedef struct ble_gap_evt_conn_param_update_t ble_gap_evt_conn_param_update_t;
+    typedef struct ble_gap_evt_sec_params_request_t ble_gap_evt_sec_params_request_t;
+    typedef struct ble_gap_evt_sec_info_request_t ble_gap_evt_sec_info_request_t;
+    typedef struct ble_gap_evt_passkey_display_t ble_gap_evt_passkey_display_t;
+    typedef struct ble_gap_evt_key_pressed_t ble_gap_evt_key_pressed_t;
+    typedef struct ble_gap_evt_auth_key_request_t ble_gap_evt_auth_key_request_t;
+    typedef struct ble_gap_evt_lesc_dhkey_request_t ble_gap_evt_lesc_dhkey_request_t;
+    typedef struct ble_gap_evt_auth_status_t ble_gap_evt_auth_status_t;
+    typedef struct ble_gap_evt_conn_sec_update_t ble_gap_evt_conn_sec_update_t;
+    typedef struct ble_gap_evt_timeout_t ble_gap_evt_timeout_t;
+    typedef struct ble_gap_evt_rssi_changed_t ble_gap_evt_rssi_changed_t;
+    typedef struct ble_gap_evt_adv_report_t ble_gap_evt_adv_report_t;
+    typedef struct ble_gap_evt_sec_request_t ble_gap_evt_sec_request_t;
+    typedef struct ble_gap_evt_conn_param_update_request_t ble_gap_evt_conn_param_update_request_t;
+    typedef struct ble_gap_evt_scan_req_report_t ble_gap_evt_scan_req_report_t;
+    typedef struct ble_gap_evt_phy_update_request_t ble_gap_evt_phy_update_request_t;
+    typedef struct ble_gap_evt_phy_update_t ble_gap_evt_phy_update_t;
+    typedef struct ble_gap_evt_data_length_update_request_t ble_gap_evt_data_length_update_request_t;
+    typedef struct ble_gap_evt_data_length_update_t ble_gap_evt_data_length_update_t;
+
+    // From ble_gap.h
+    typedef struct
+    {
+      uint16_t conn_handle;                                     /**< Connection Handle on which event occurred. */
+      union                                /**< union alternative identified by evt_id in enclosing struct. */
+      {
+        ble_gap_evt_connected_t                   connected;                    /**< Connected Event Parameters. */
+        ble_gap_evt_disconnected_t                disconnected;                 /**< Disconnected Event Parameters. */
+        ble_gap_evt_conn_param_update_t           conn_param_update;            /**< Connection Parameter Update Parameters. */
+        ble_gap_evt_sec_params_request_t          sec_params_request;           /**< Security Parameters Request Event Parameters. */
+        ble_gap_evt_sec_info_request_t            sec_info_request;             /**< Security Information Request Event Parameters. */
+        ble_gap_evt_passkey_display_t             passkey_display;              /**< Passkey Display Event Parameters. */
+        ble_gap_evt_key_pressed_t                 key_pressed;                  /**< Key Pressed Event Parameters. */
+        ble_gap_evt_auth_key_request_t            auth_key_request;             /**< Authentication Key Request Event Parameters. */
+        ble_gap_evt_lesc_dhkey_request_t          lesc_dhkey_request;           /**< LE Secure Connections DHKey calculation request. */
+        ble_gap_evt_auth_status_t                 auth_status;                  /**< Authentication Status Event Parameters. */
+        ble_gap_evt_conn_sec_update_t             conn_sec_update;              /**< Connection Security Update Event Parameters. */
+        ble_gap_evt_timeout_t                     timeout;                      /**< Timeout Event Parameters. */
+        ble_gap_evt_rssi_changed_t                rssi_changed;                 /**< RSSI Event Parameters. */
+        ble_gap_evt_adv_report_t                  adv_report;                   /**< Advertising Report Event Parameters. */
+        ble_gap_evt_sec_request_t                 sec_request;                  /**< Security Request Event Parameters. */
+        ble_gap_evt_conn_param_update_request_t   conn_param_update_request;    /**< Connection Parameter Update Parameters. */
+        ble_gap_evt_scan_req_report_t             scan_req_report;              /**< Scan Request Report Parameters. */
+        ble_gap_evt_phy_update_request_t          phy_update_request;           /**< PHY Update Request Event Parameters. */
+        ble_gap_evt_phy_update_t                  phy_update;                   /**< PHY Update Parameters. */
+        ble_gap_evt_data_length_update_request_t  data_length_update_request;   /**< Data Length Update Request Event Parameters. */
+        ble_gap_evt_data_length_update_t          data_length_update;           /**< Data Length Update Event Parameters. */
+      } params;                                                                 /**< Event Parameters. */
+    } ble_gap_evt_t;
+
+    // ble_gatts.h
+    // Forward declaration of structs
+    typedef struct ble_gatts_authorize_params_t ble_gatts_authorize_params_t;
+    typedef struct ble_gatts_evt_write_t ble_gatts_evt_write_t;
+    typedef struct ble_gatts_evt_rw_authorize_request_t ble_gatts_evt_rw_authorize_request_t;
+    typedef struct ble_gatts_evt_sys_attr_missing_t ble_gatts_evt_sys_attr_missing_t;
+    typedef struct ble_gatts_evt_hvc_t ble_gatts_evt_hvc_t;
+    typedef struct ble_gatts_evt_timeout_t ble_gatts_evt_timeout_t;
+
+    // From ble_gatts.h
+    typedef struct
+    {
+      uint8_t                               type;   /**< Type of authorize operation, see @ref BLE_GATTS_AUTHORIZE_TYPES. */
+      union
+      {
+        ble_gatts_authorize_params_t        read;   /**< Read authorization parameters. */
+        ble_gatts_authorize_params_t        write;  /**< Write authorization parameters. */
+      } params;                                     /**< Reply Parameters. */
+    } ble_gatts_rw_authorize_reply_params_t;
+
+    typedef struct
+    {
+      uint16_t conn_handle;                                       /**< Connection Handle on which the event occurred. */
+      union
+      {
+        ble_gatts_evt_write_t                 write;              /**< Write Event Parameters. */
+        ble_gatts_evt_rw_authorize_request_t  authorize_request;  /**< Read or Write Authorize Request Parameters. */
+        ble_gatts_evt_sys_attr_missing_t      sys_attr_missing;   /**< System attributes missing. */
+        ble_gatts_evt_hvc_t                   hvc;                /**< Handle Value Confirmation Event Parameters. */
+        ble_gatts_evt_timeout_t               timeout;            /**< Timeout Event. */
+      } params;                                                   /**< Event Parameters. */
+    } ble_gatts_evt_t;
+
+    // ble_gattc.h
+    // Forward declaration of structs
+    typedef struct ble_gattc_evt_prim_srvc_disc_rsp_t ble_gattc_evt_prim_srvc_disc_rsp_t;
+    typedef struct ble_gattc_evt_rel_disc_rsp_t ble_gattc_evt_rel_disc_rsp_t;
+    typedef struct ble_gattc_evt_char_disc_rsp_t ble_gattc_evt_char_disc_rsp_t;
+    typedef struct ble_gattc_evt_desc_disc_rsp_t ble_gattc_evt_desc_disc_rsp_t;
+    typedef struct ble_gattc_evt_char_val_by_uuid_read_rsp_t ble_gattc_evt_char_val_by_uuid_read_rsp_t;
+    typedef struct ble_gattc_evt_read_rsp_t ble_gattc_evt_read_rsp_t;
+    typedef struct ble_gattc_evt_char_vals_read_rsp_t ble_gattc_evt_char_vals_read_rsp_t;
+    typedef struct ble_gattc_evt_write_rsp_t ble_gattc_evt_write_rsp_t;
+    typedef struct ble_gattc_evt_hvx_t ble_gattc_evt_hvx_t;
+    typedef struct ble_gattc_evt_timeout_t ble_gattc_evt_timeout_t;
+    typedef struct ble_gattc_evt_attr_info_disc_rsp_t ble_gattc_evt_attr_info_disc_rsp_t;
+
+    // From ble_gattc.h
+    typedef struct
+    {
+      uint16_t            conn_handle;                /**< Connection Handle on which event occured. */
+      uint16_t            gatt_status;                /**< GATT status code for the operation, see @ref BLE_GATT_STATUS_CODES. */
+      uint16_t            error_handle;               /**< In case of error: The handle causing the error. In all other cases @ref BLE_GATT_HANDLE_INVALID. */
+      union
+      {
+        ble_gattc_evt_prim_srvc_disc_rsp_t          prim_srvc_disc_rsp;         /**< Primary Service Discovery Response Event Parameters. */
+        ble_gattc_evt_rel_disc_rsp_t                rel_disc_rsp;               /**< Relationship Discovery Response Event Parameters. */
+        ble_gattc_evt_char_disc_rsp_t               char_disc_rsp;              /**< Characteristic Discovery Response Event Parameters. */
+        ble_gattc_evt_desc_disc_rsp_t               desc_disc_rsp;              /**< Descriptor Discovery Response Event Parameters. */
+        ble_gattc_evt_char_val_by_uuid_read_rsp_t   char_val_by_uuid_read_rsp;  /**< Characteristic Value Read by UUID Response Event Parameters. */
+        ble_gattc_evt_read_rsp_t                    read_rsp;                   /**< Read Response Event Parameters. */
+        ble_gattc_evt_char_vals_read_rsp_t          char_vals_read_rsp;         /**< Characteristic Values Read Response Event Parameters. */
+        ble_gattc_evt_write_rsp_t                   write_rsp;                  /**< Write Response Event Parameters. */
+        ble_gattc_evt_hvx_t                         hvx;                        /**< Handle Value Notification/Indication Event Parameters. */
+        ble_gattc_evt_timeout_t                     timeout;                    /**< Timeout Event Parameters. */
+        ble_gattc_evt_attr_info_disc_rsp_t          attr_info_disc_rsp;         /**< Attribute Information Discovery Event Parameters. */
+      } params;                                                                 /**< Event Parameters. @note Only valid if @ref gatt_status == @ref BLE_GATT_STATUS_SUCCESS. */
+    } ble_gattc_evt_t;
+
+    // ble_l2cap.h
+    // Forward declaration of structs
+    typedef struct ble_l2cap_evt_ch_setup_request_t ble_l2cap_evt_ch_setup_request_t;
+    typedef struct ble_l2cap_evt_ch_setup_refused_t ble_l2cap_evt_ch_setup_refused_t;
+    typedef struct ble_l2cap_evt_ch_setup_t ble_l2cap_evt_ch_setup_t;
+    typedef struct ble_l2cap_evt_ch_sdu_buf_released_t ble_l2cap_evt_ch_sdu_buf_released_t;
+    typedef struct ble_l2cap_evt_ch_credit_t ble_l2cap_evt_ch_credit_t;
+    typedef struct ble_l2cap_evt_ch_rx_t ble_l2cap_evt_ch_rx_t;
+    typedef struct ble_l2cap_evt_ch_tx_t ble_l2cap_evt_ch_tx_t;
+
+    // From ble_l2cap.h
+    typedef struct
+    {
+      uint16_t conn_handle;                                     /**< Connection Handle on which the event occured. */
+      uint16_t local_cid;                                       /**< Local Channel ID of the L2CAP channel, or
+                                                                     @ref BLE_L2CAP_CID_INVALID if not present. */
+      union
+      {
+        ble_l2cap_evt_ch_setup_request_t    ch_setup_request;   /**< L2CAP Channel Setup Request Event Parameters. */
+        ble_l2cap_evt_ch_setup_refused_t    ch_setup_refused;   /**< L2CAP Channel Setup Refused Event Parameters. */
+        ble_l2cap_evt_ch_setup_t            ch_setup;           /**< L2CAP Channel Setup Completed Event Parameters. */
+        ble_l2cap_evt_ch_sdu_buf_released_t ch_sdu_buf_released;/**< L2CAP Channel SDU Data Buffer Released Event Parameters. */
+        ble_l2cap_evt_ch_credit_t           credit;             /**< L2CAP Channel Credit Received Event Parameters. */
+        ble_l2cap_evt_ch_rx_t               rx;                 /**< L2CAP Channel SDU Received Event Parameters. */
+        ble_l2cap_evt_ch_tx_t               tx;                 /**< L2CAP Channel SDU Transmitted Event Parameters. */
+      } params;                                                 /**< Event Parameters. */
+    } ble_l2cap_evt_t;
+
+#endif // NRF_SD_BLE_API_VERSION == 5
+
+#if NRF_SD_BLE_API_VERSION == 2
+    // SoftDevice V2
+
+    // ble.h
+    // Forward declaration of structs
+    typedef ble_evt_tx_complete_t ble_evt_tx_complete_t;
+    typedef ble_evt_user_mem_request_t ble_evt_user_mem_request_t;
+    typedef ble_evt_user_mem_release_t ble_evt_user_mem_release_t;
+
+    // From ble.h
+    typedef struct
+    {
+      uint16_t conn_handle;                 /**< Connection Handle on which this event occurred. */
+      union
+      {
+        ble_evt_tx_complete_t           tx_complete;        /**< Transmission Complete. */
+        ble_evt_user_mem_request_t      user_mem_request;   /**< User Memory Request Event Parameters. */
+        ble_evt_user_mem_release_t      user_mem_release;   /**< User Memory Release Event Parameters. */
+      } params;
+    } ble_common_evt_t;
+
+    // ble_gap.h
+    // Forward declaration of structs
+    typedef struct ble_gap_evt_connected_t ble_gap_evt_connected_t;
+    typedef struct ble_gap_evt_disconnected_t ble_gap_evt_disconnected_t;
+    typedef struct ble_gap_evt_conn_param_update_t ble_gap_evt_conn_param_update_t;
+    typedef struct ble_gap_evt_sec_params_request_t ble_gap_evt_sec_params_request_t;
+    typedef struct ble_gap_evt_sec_info_request_t ble_gap_evt_sec_info_request_t;
+    typedef struct ble_gap_evt_passkey_display_t ble_gap_evt_passkey_display_t;
+    typedef struct ble_gap_evt_key_pressed_t ble_gap_evt_key_pressed_t;
+    typedef struct ble_gap_evt_auth_key_request_t ble_gap_evt_auth_key_request_t;
+    typedef struct ble_gap_evt_lesc_dhkey_request_t ble_gap_evt_lesc_dhkey_request_t;
+    typedef struct ble_gap_evt_auth_status_t ble_gap_evt_auth_status_t;
+    typedef struct ble_gap_evt_conn_sec_update_t ble_gap_evt_conn_sec_update_t;
+    typedef struct ble_gap_evt_timeout_t ble_gap_evt_timeout_t;
+    typedef struct ble_gap_evt_rssi_changed_t ble_gap_evt_rssi_changed_t;
+    typedef struct ble_gap_evt_adv_report_t ble_gap_evt_adv_report_t;
+    typedef struct ble_gap_evt_sec_request_t ble_gap_evt_sec_request_t;
+    typedef struct ble_gap_evt_conn_param_update_request_t ble_gap_evt_conn_param_update_request_t;
+    typedef struct ble_gap_evt_scan_req_report_t ble_gap_evt_scan_req_report_t;
+
+    // From ble_gap.h
+    typedef struct
+    {
+      uint16_t conn_handle;                                     /**< Connection Handle on which event occurred. */
+      union                                /**< union alternative identified by evt_id in enclosing struct. */
+      {
+        ble_gap_evt_connected_t                   connected;                    /**< Connected Event Parameters. */
+        ble_gap_evt_disconnected_t                disconnected;                 /**< Disconnected Event Parameters. */
+        ble_gap_evt_conn_param_update_t           conn_param_update;            /**< Connection Parameter Update Parameters. */
+        ble_gap_evt_sec_params_request_t          sec_params_request;           /**< Security Parameters Request Event Parameters. */
+        ble_gap_evt_sec_info_request_t            sec_info_request;             /**< Security Information Request Event Parameters. */
+        ble_gap_evt_passkey_display_t             passkey_display;              /**< Passkey Display Event Parameters. */
+        ble_gap_evt_key_pressed_t                 key_pressed;                  /**< Key Pressed Event Parameters. */
+        ble_gap_evt_auth_key_request_t            auth_key_request;             /**< Authentication Key Request Event Parameters. */
+        ble_gap_evt_lesc_dhkey_request_t          lesc_dhkey_request;           /**< LE Secure Connections DHKey calculation request. */
+        ble_gap_evt_auth_status_t                 auth_status;                  /**< Authentication Status Event Parameters. */
+        ble_gap_evt_conn_sec_update_t             conn_sec_update;              /**< Connection Security Update Event Parameters. */
+        ble_gap_evt_timeout_t                     timeout;                      /**< Timeout Event Parameters. */
+        ble_gap_evt_rssi_changed_t                rssi_changed;                 /**< RSSI Event parameters. */
+        ble_gap_evt_adv_report_t                  adv_report;                   /**< Advertising Report Event Parameters. */
+        ble_gap_evt_sec_request_t                 sec_request;                  /**< Security Request Event Parameters. */
+        ble_gap_evt_conn_param_update_request_t   conn_param_update_request;    /**< Connection Parameter Update Parameters. */
+        ble_gap_evt_scan_req_report_t             scan_req_report;              /**< Scan Request Report parameters. */
+      } params;                                                                 /**< Event Parameters. */
+    } ble_gap_evt_t;
+
+    // ble_gatts.h
+    // Forward declaration of structs
+    typedef struct ble_gatts_evt_write_t ble_gatts_evt_write_t;
+    typedef struct ble_gatts_evt_rw_authorize_request_t ble_gatts_evt_rw_authorize_request_t;
+    typedef struct ble_gatts_evt_sys_attr_missing_t ble_gatts_evt_sys_attr_missing_t;
+    typedef struct ble_gatts_evt_hvc_t ble_gatts_evt_hvc_t;
+    typedef struct ble_gatts_evt_timeout_t ble_gatts_evt_timeout_t;
+    typedef struct ble_gatts_authorize_params_t ble_gatts_authorize_params_t;
+
+    // From ble_gatts.h
+    typedef struct
+    {
+      uint8_t                               type;   /**< Type of authorize operation, see @ref BLE_GATTS_AUTHORIZE_TYPES. */
+      union
+      {
+        ble_gatts_authorize_params_t        read;   /**< Read authorization parameters. */
+        ble_gatts_authorize_params_t        write;  /**< Write authorization parameters. */
+      } params;                                     /**< Reply Parameters. */
+    } ble_gatts_rw_authorize_reply_params_t;
+
+    typedef struct
+    {
+      uint16_t conn_handle;                                       /**< Connection Handle on which the event occurred. */
+      union
+      {
+        ble_gatts_evt_write_t                 write;              /**< Write Event Parameters. */
+        ble_gatts_evt_rw_authorize_request_t  authorize_request;  /**< Read or Write Authorize Request Parameters. */
+        ble_gatts_evt_sys_attr_missing_t      sys_attr_missing;   /**< System attributes missing. */
+        ble_gatts_evt_hvc_t                   hvc;                /**< Handle Value Confirmation Event Parameters. */
+        ble_gatts_evt_timeout_t               timeout;            /**< Timeout Event. */
+      } params;                                                   /**< Event Parameters. */
+    } ble_gatts_evt_t;
+
+    // ble_gattc.h
+    // Forward declaration of structs
+    typedef struct ble_gattc_evt_prim_srvc_disc_rsp_t ble_gattc_evt_prim_srvc_disc_rsp_t;
+    typedef struct ble_gattc_evt_rel_disc_rsp_t ble_gattc_evt_rel_disc_rsp_t;
+    typedef struct ble_gattc_evt_char_disc_rsp_t ble_gattc_evt_char_disc_rsp_t;
+    typedef struct ble_gattc_evt_desc_disc_rsp_t ble_gattc_evt_desc_disc_rsp_t;
+    typedef struct ble_gattc_evt_char_val_by_uuid_read_rsp_t ble_gattc_evt_char_val_by_uuid_read_rsp_t;
+    typedef struct ble_gattc_evt_read_rsp_t ble_gattc_evt_read_rsp_t;
+    typedef struct ble_gattc_evt_char_vals_read_rsp_t ble_gattc_evt_char_vals_read_rsp_t;
+    typedef struct ble_gattc_evt_write_rsp_t ble_gattc_evt_write_rsp_t;
+    typedef struct ble_gattc_evt_hvx_t ble_gattc_evt_hvx_t;
+    typedef struct ble_gattc_evt_timeout_t ble_gattc_evt_timeout_t;
+    typedef struct ble_gattc_evt_attr_info_disc_rsp_t ble_gattc_evt_attr_info_disc_rsp_t;
+
+    // From ble_gattc.h
+    typedef struct
+    {
+      uint16_t            conn_handle;                /**< Connection Handle on which event occured. */
+      uint16_t            gatt_status;                /**< GATT status code for the operation, see @ref BLE_GATT_STATUS_CODES. */
+      uint16_t            error_handle;               /**< In case of error: The handle causing the error. In all other cases @ref BLE_GATT_HANDLE_INVALID. */
+      union
+      {
+        ble_gattc_evt_prim_srvc_disc_rsp_t          prim_srvc_disc_rsp;         /**< Primary Service Discovery Response Event Parameters. */
+        ble_gattc_evt_rel_disc_rsp_t                rel_disc_rsp;               /**< Relationship Discovery Response Event Parameters. */
+        ble_gattc_evt_char_disc_rsp_t               char_disc_rsp;              /**< Characteristic Discovery Response Event Parameters. */
+        ble_gattc_evt_desc_disc_rsp_t               desc_disc_rsp;              /**< Descriptor Discovery Response Event Parameters. */
+        ble_gattc_evt_char_val_by_uuid_read_rsp_t   char_val_by_uuid_read_rsp;  /**< Characteristic Value Read by UUID Response Event Parameters. */
+        ble_gattc_evt_read_rsp_t                    read_rsp;                   /**< Read Response Event Parameters. */
+        ble_gattc_evt_char_vals_read_rsp_t          char_vals_read_rsp;         /**< Characteristic Values Read Response Event Parameters. */
+        ble_gattc_evt_write_rsp_t                   write_rsp;                  /**< Write Response Event Parameters. */
+        ble_gattc_evt_hvx_t                         hvx;                        /**< Handle Value Notification/Indication Event Parameters. */
+        ble_gattc_evt_timeout_t                     timeout;                    /**< Timeout Event Parameters. */
+        ble_gattc_evt_attr_info_disc_rsp_t          attr_info_disc_rsp;         /**< Attribute Information Discovery Event Parameters. */
+      } params;                                                                 /**< Event Parameters. @note Only valid if @ref gatt_status == @ref BLE_GATT_STATUS_SUCCESS. */
+    } ble_gattc_evt_t;
+
+    // ble_l2cap.h
+    // Forward declaration of structs
+    typedef struct ble_l2cap_evt_rx_t ble_l2cap_evt_rx_t;
+
+    // From ble_l2cap.h
+    typedef struct
+    {
+      uint16_t conn_handle;                           /**< Connection Handle on which event occured. */
+      union
+      {
+        ble_l2cap_evt_rx_t rx;                        /**< RX Event parameters. */
+      } params;                                       /**< Event Parameters. */
+    } ble_l2cap_evt_t;
+#endif // NRF_SD_BLE_API_VERSION == 2
+
+%}
 
 // Grab the definitions
 %include "config/platform.h"


### PR DESCRIPTION
**Updated pc-ble-driver submodule to the latest in master**
Fixes to open timeout issues are added in latest pc-ble-driver.

**Fix deprecation error for CMake SWIG commands**
Since pc-ble-driver now requires cmake 3.11 this module should also use that.
Using CMake 3.11 creates a deprecation error for the CMake SWIG commands.
This PR updates the CMake SWIG commands.

**Update to use Python 3.4 as default**
The purpose of this PR is to support Python 3.4.

**A fix to circumvent SWIG issues**
SWIG has an issue with unions that are named. See swig/swig#1305.

In pc-ble-driver there are several structs that use named unions.

For example:

```
typedef struct
{
  uint16_t conn_handle;
  union common_evt_params_union
  {
    ble_evt_tx_complete_t           tx_complete;
    ble_evt_user_mem_request_t      user_mem_request;
    ble_evt_user_mem_release_t      user_mem_release;
  } params;
} ble_common_evt_t;

```
SWIG is not able to add a params struct member with this syntax.
However, removing common_evt_params_union works.

This PR circumvent this by inlining structs with the union name removed.

@jorgenmk I've done this PR towards your repo so that you can update the pull request you have (https://github.com/NordicSemiconductor/pc-ble-driver-py/pull/48)